### PR TITLE
fix #4

### DIFF
--- a/src/Rate.js
+++ b/src/Rate.js
@@ -13,12 +13,46 @@ class Rate extends React.Component {
 
   constructor(props) {
     super(props);
+
+    this.state = {
+      hover: props.value
+    };
+  }
+
+  componentWillReceiveProps(nextProps){
+    if (nextProps.value !== this.props.value){
+      this.setState({
+        hover: nextProps.value
+      });
+    }
+  }
+
+  handleItemHover(i){
+    if (this.props.disabled){
+      console.log('return');
+      return;
+    }
+
+    this.setState({
+      hover: i
+    });
+  }
+
+  handleItemLeave(){
+    if (this.props.disabled){
+      return;
+    }
+
+    this.setState({
+      hover: this.props.value
+    });
   }
 
   handleItemClick(v, disabled) {
-    if (disabled) {
+    if (this.props.disabled){
       return;
     }
+
     this.props.onChange(v);
   }
 
@@ -30,14 +64,14 @@ class Rate extends React.Component {
     });
 
     return (
-      <div className={classes}>
+      <div className={classes} onMouseLeave={this.handleItemLeave.bind(this)}>
         {
           // 根据totalScore,造一个数组，仅用于执行map方法
           new Array(t.props.total).fill(1).map((v, k) => {
             return (
               <div className={classnames(`${t.props.prefixCls}-item`, {
-                  'active': (k + 1) <= t.props.value
-                })} key={k + 1} onClick={t.handleItemClick.bind(t, k + 1, t.props.disabled)}>
+                  'active': (k + 1) <= t.state.hover
+                })} key={k + 1} onClick={t.handleItemClick.bind(t, k + 1)} onMouseEnter={t.handleItemHover.bind(t, k+1)}>
                 {
                   t.props.scoreTips[k] ?
                     <Tooltip placement="top" trigger="hover" overlay={t.props.scoreTips[k]}>

--- a/src/Rate.less
+++ b/src/Rate.less
@@ -23,9 +23,4 @@
   &.active {
     color: @brand-primary;
   }
-  &:hover .kuma-icon {
-    color: @brand-primary-light;
-    transform: scale(1.1);
-    transition: all @transition-duration @transition-ease @transition-delay;
-  }
 }


### PR DESCRIPTION
增加`handleItemHover`及`handleItemLeave`逻辑，星星点亮完全由state.hover的值来控制。

遗留问题：根据上述逻辑，星星点亮不应该再有hover样式来处理，因此需要把global的kuma-rate-item:hover的样式去掉，或者组件自己写样式，否则在disabled状态时，会有一点不一致
